### PR TITLE
install_requires fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,15 +14,6 @@ from os.path import splitext
 from setuptools import find_packages
 from setuptools import setup
 
-try:  # for pip >= 10
-    from pip._internal.req import parse_requirements
-except ImportError:  # for pip <= 9.0.3
-    from pip.req import parse_requirements
-
-install_reqs = parse_requirements('requirements.txt', session=False)
-
-reqs = [str(ir.req) for ir in install_reqs]
-
 
 def read(*names, **kwargs):
     with io.open(
@@ -84,7 +75,7 @@ setup(
         # eg: 'keyword1', 'keyword2', 'keyword3',
     ],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
-    install_requires=reqs,
+    install_requires=[r.strip() for r in open('requirements.txt').read().splitlines()],
     extras_require={
         # eg:
         #   'rst': ['docutils>=0.11'],


### PR DESCRIPTION
Com o codigo atual eu tenho esse erro com essa versao recente do pip:
```
odoo@-:/$ pip --version
pip 20.1.1 from /usr/local/lib/python3.5/dist-packages/pip (python 3.5)
```

Eu tinha uma versao um pouco mais antiga (nao sei qual) e dava o mesmo erro, por isso atualizei meu pip para o 20.1.1 e continuou com o erro. Eu nao sei se esse fix eh legal para todas versoes do pip mas para essa versao 20.1.1 resolveu...

```
Obtaining erpbrasil.transmissao from git+git://github.com/erpbrasil/erpbrasil.transmissao.git#egg=erpbrasil.transmissao (from -r /odoo/requirements.txt (line 18))
  Cloning git://github.com/erpbrasil/erpbrasil.transmissao.git to /src/erpbrasil.transmissao
  Running command git clone -q git://github.com/erpbrasil/erpbrasil.transmissao.git /src/erpbrasil.transmissao
    ERROR: Command errored out with exit status 1:
     command: /usr/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/src/erpbrasil.transmissao/setup.py'"'"'; __file__='"'"'/src/erpbrasil.transmissao/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-5uh4ux5f
         cwd: /src/erpbrasil.transmissao/
    Complete output (7 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/src/erpbrasil.transmissao/setup.py", line 24, in <module>
        reqs = [str(ir.req) for ir in install_reqs]
      File "/src/erpbrasil.transmissao/setup.py", line 24, in <listcomp>
        reqs = [str(ir.req) for ir in install_reqs]
    AttributeError: 'ParsedRequirement' object has no attribute 'req'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
ERROR: Service 'odoo' failed to build: The command '/bin/sh -c pip install -r /odoo/requirements.txt' returned a non-zero code: 1
Traceback (most recent call last):
```